### PR TITLE
Responsividade da pagina de listagem de planos

### DIFF
--- a/src/app/admin/plans/_components/AdminPlanCard.tsx
+++ b/src/app/admin/plans/_components/AdminPlanCard.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Button } from '@/components/Button';
+import { ScenarioResponseDTO } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+import { Check, FileDown, Pencil, X } from 'lucide-react';
+
+interface AdminPlanCardProps {
+  plan: ScenarioResponseDTO;
+  onEdit: (id: string) => void;
+  onDownload: (scenario: ScenarioResponseDTO) => void;
+  onPublish: (scenario: ScenarioResponseDTO) => void;
+}
+
+export const AdminPlanCard = ({
+  plan,
+  onEdit,
+  onDownload,
+  onPublish,
+}: AdminPlanCardProps) => {
+  const lastUpdated =
+    plan.tasks && plan.tasks.length > 0
+      ? plan.tasks.reduce((latest, current) => {
+          const latestDate = new Date(latest.lastUpdateDate);
+          const currentDate = new Date(current.lastUpdateDate);
+          return currentDate > latestDate ? current : latest;
+        }).lastUpdateDate
+      : null;
+
+  return (
+    <div className="w-full rounded-lg border border-gray-200 bg-white p-2 shadow-sm">
+      <div className="mb-2">
+        <div className="mb-1">
+          <span className="text-xs text-gray-500">Cidade</span>
+          <p className="text-sm font-semibold text-gray-800">
+            {plan.city ? `${plan.city.name} - ${plan.city.state}` : '—'}
+          </p>
+        </div>
+        <div>
+          <span className="text-xs text-gray-500">Cobrade</span>
+          <p className="text-sm text-gray-700">
+            {`${plan.cobrade.code} - ${plan.cobrade.subType || plan.cobrade.type || plan.cobrade.subgroup}`}
+          </p>
+        </div>
+      </div>
+
+      <div className="mb-2 grid grid-cols-2 gap-3">
+        <div>
+          <span className="text-xs text-gray-500">Última Atualização</span>
+          <p className="text-sm font-medium text-gray-700">
+            {lastUpdated ? formatDate(lastUpdated) : '—'}
+          </p>
+        </div>
+        <div>
+          <span className="text-xs text-gray-500">Status</span>
+          <p
+            className={`text-sm font-semibold ${
+              plan.published ? 'text-green-600' : 'text-yellow-700'
+            }`}
+          >
+            {plan.published ? 'Publicado' : 'Não Publicado'}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col space-y-1">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onEdit(plan.id)}
+          leftIcon={<Pencil size={16} />}
+        >
+          Editar
+        </Button>
+        <div className="flex space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={() => !plan.published && onPublish(plan)}
+            disabled={plan.published}
+            leftIcon={plan.published ? <Check size={16} /> : <X size={16} />}
+          >
+            {plan.published ? 'Publicado' : 'Publicar'}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={() => onDownload(plan)}
+            disabled={!plan.published}
+            leftIcon={<FileDown size={16} />}
+          >
+            Download
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/app/admin/plans/_components/FiltersBar.tsx
+++ b/src/app/admin/plans/_components/FiltersBar.tsx
@@ -108,7 +108,7 @@ export function FiltersBar({
 
         <div
           className={`flex w-full flex-col items-start gap-5 px-6 md:flex-row ${
-            publishedSearchable ? 'ml-20 md:items-center' : 'md:items-end'
+            publishedSearchable ? 'md:items-center' : 'md:items-end'
           }`}
         >
           <Button variant="terciary" onClick={onClearFilters} type="button">

--- a/src/app/admin/plans/_components/FiltersBar.tsx
+++ b/src/app/admin/plans/_components/FiltersBar.tsx
@@ -40,8 +40,8 @@ export function FiltersBar({
       onSubmit={handleSubmit}
       className="mb-6 flex flex-col gap-4 md:flex-row md:items-end"
     >
-      <div className="flex w-full flex-col items-start gap-5 px-6 md:flex-row md:items-end">
-        <div className="flex w-full max-w-lg gap-4">
+      <div className="flex w-full max-w-[675px] flex-col gap-4 px-6 md:flex-row md:items-end">
+        <div className="flex flex-1 gap-4">
           <div className="flex-1">
             <label
               htmlFor="city-search"
@@ -107,8 +107,8 @@ export function FiltersBar({
         </div>
 
         <div
-          className={`flex w-full flex-col items-start gap-5 px-6 md:flex-row ${
-            publishedSearchable ? 'md:items-center' : 'md:items-end'
+          className={`flex gap-3 ${
+            publishedSearchable ? 'items-center' : 'items-end'
           }`}
         >
           <Button variant="terciary" onClick={onClearFilters} type="button">

--- a/src/app/admin/plans/page.tsx
+++ b/src/app/admin/plans/page.tsx
@@ -12,7 +12,10 @@ import { useRouter } from 'next/navigation';
 import DownloadModal from '@/components/DownloadModal';
 import { FiltersBar } from './_components/FiltersBar';
 import { PlansTable } from './_components/PlansTable';
+import { AdminPlanCard } from './_components/AdminPlanCard';
 import { ConfirmPublishModal } from './_components/ConfirmPublishModal';
+import FiltersModal from '@/components/FiltersModal';
+import { Filter } from 'lucide-react';
 
 type Field = 'cityId' | 'serviceId' | 'cobrade';
 type Errors = Partial<Record<Field, string>>;
@@ -60,6 +63,8 @@ export default function AdminPlansPage() {
     useState<ScenarioResponseDTO | null>(null);
   const [publishLoading, setPublishLoading] = useState(false);
 
+  const [isFiltersModalOpen, setIsFiltersModalOpen] = useState(false);
+
   const { success, error } = useToast();
   const { showLoading, hideLoading } = useLoading();
   const loadingShown = useRef(false);
@@ -91,6 +96,7 @@ export default function AdminPlansPage() {
     setAppliedCityFilter(adjustedCity);
     setAppliedCobradeFilter(pendingCobradeFilter);
     setAppliedPublishedFilter(pendingPublishedFilter);
+    setIsFiltersModalOpen(false);
   };
 
   const handleClearFilters = () => {
@@ -100,6 +106,7 @@ export default function AdminPlansPage() {
     setAppliedCityFilter(null);
     setAppliedCobradeFilter(null);
     setAppliedPublishedFilter(null);
+    setIsFiltersModalOpen(false);
   };
 
   const filteredScenarios = useMemo(() => {
@@ -217,41 +224,68 @@ export default function AdminPlansPage() {
   }
 
   return (
-    <main className="mx-auto mt-20 w-full flex-1 px-6 py-6">
-      <div className="mb-5 ml-5 flex items-center justify-between">
+    <div className="mx-auto mt-20 w-full flex-1 px-6 py-6">
+      <div className="mb-5 flex items-center justify-between">
         <h1 className="mb-5 text-3xl font-bold">Planos de Contingência</h1>
       </div>
 
-      <FiltersBar
-        cobradeOptions={cobradeOptions}
-        cityOptions={cityNames}
-        cityValue={pendingCityFilter}
-        onSelectCity={setPendingCityFilter}
-        onSelectCobrade={setPendingCobradeFilter}
-        cobradeValue={pendingCobradeFilter}
-        onSearch={handleSearch}
-        onClearFilters={handleClearFilters}
-        publishedSearchable={true}
-        publishedValue={pendingPublishedFilter}
-        onSelectPublished={setPendingPublishedFilter}
-      />
+      <div className="mb-5 flex md:hidden">
+        <button
+          onClick={() => setIsFiltersModalOpen(true)}
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+        >
+          <Filter className="h-4 w-4" />
+          Filtrar
+        </button>
+      </div>
+
+      <div className="hidden md:block">
+        <FiltersBar
+          cobradeOptions={cobradeOptions}
+          cityOptions={cityNames}
+          cityValue={pendingCityFilter}
+          onSelectCity={setPendingCityFilter}
+          onSelectCobrade={setPendingCobradeFilter}
+          cobradeValue={pendingCobradeFilter}
+          onSearch={handleSearch}
+          onClearFilters={handleClearFilters}
+          publishedSearchable={true}
+          publishedValue={pendingPublishedFilter}
+          onSelectPublished={setPendingPublishedFilter}
+        />
+      </div>
 
       {loading ? (
         <div className="rounded-lg border border-gray-200 bg-white p-6 text-center text-gray-700">
           Carregando planos...
         </div>
       ) : (
-        <PlansTable
-          rows={filteredScenarios}
-          showPagination={showPagination}
-          selectedPlanIds={selectedScenarioIds}
-          onSelectionChange={setSelectedScenarioIds}
-          isEditable={true}
-          isPublishable={true}
-          onEdit={onEdit}
-          onDownload={handleDownload}
-          onPublish={onPublish}
-        />
+        <>
+          <div className="hidden md:block">
+            <PlansTable
+              rows={filteredScenarios}
+              showPagination={showPagination}
+              selectedPlanIds={selectedScenarioIds}
+              onSelectionChange={setSelectedScenarioIds}
+              isEditable={true}
+              isPublishable={true}
+              onEdit={onEdit}
+              onDownload={handleDownload}
+              onPublish={onPublish}
+            />
+          </div>
+          <div className="space-y-4 md:hidden">
+            {filteredScenarios.map((plan) => (
+              <AdminPlanCard
+                key={plan.id}
+                plan={plan}
+                onEdit={onEdit}
+                onDownload={handleDownload}
+                onPublish={onPublish}
+              />
+            ))}
+          </div>
+        </>
       )}
 
       {selectedScenarioIds.length > 0 && (
@@ -290,6 +324,22 @@ export default function AdminPlansPage() {
         onConfirm={handleConfirmPublish}
         onClose={() => setPublishModalOpen(false)}
       />
-    </main>
+
+      <FiltersModal
+        isOpen={isFiltersModalOpen}
+        onClose={() => setIsFiltersModalOpen(false)}
+        cityOptions={cityNames}
+        cobradeOptions={cobradeOptions}
+        cityValue={pendingCityFilter}
+        cobradeValue={pendingCobradeFilter}
+        onSelectCity={setPendingCityFilter}
+        onSelectCobrade={setPendingCobradeFilter}
+        onApplyFilters={handleSearch}
+        onClearFilters={handleClearFilters}
+        publishedOptions={['Publicado', 'Não publicado']}
+        publishedValue={pendingPublishedFilter}
+        onSelectPublished={setPendingPublishedFilter}
+      />
+    </div>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -49,7 +49,7 @@ const buttonClasses = cva(
         save: 'bg-green-600 text-white hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-0',
       },
       size: {
-        sm: 'h-8 px-3 text-sm rounded-[8px] min-w-[100px]',
+        sm: 'h-7 px-3 text-sm rounded-[8px]',
         md: 'h-10 px-4 text-sm rounded-[8px] min-w-[120px]',
         lg: 'h-12 px-6 text-base rounded-[8px] min-w-[140px]',
         xl: 'h-14 px-8 text-lg rounded-[8px] min-w-[180px]',

--- a/src/components/FiltersModal.tsx
+++ b/src/components/FiltersModal.tsx
@@ -13,6 +13,9 @@ type FiltersModalProps = {
   onSelectCobrade: (value: string | null) => void;
   onApplyFilters: () => void;
   onClearFilters: () => void;
+  publishedOptions?: string[];
+  publishedValue?: string | null;
+  onSelectPublished?: (value: string | null) => void;
 };
 
 export default function FiltersModal({
@@ -26,6 +29,9 @@ export default function FiltersModal({
   onSelectCobrade,
   onApplyFilters,
   onClearFilters,
+  publishedOptions,
+  publishedValue,
+  onSelectPublished,
 }: FiltersModalProps) {
   const handleApply = () => {
     onApplyFilters();
@@ -94,6 +100,22 @@ export default function FiltersModal({
                   useAutoComplete
                 />
               </div>
+
+              {publishedOptions && onSelectPublished && (
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-gray-700">
+                    Status de Publicação:
+                  </label>
+                  <Dropdown
+                    label="Selecione o Status"
+                    items={publishedOptions}
+                    onSelect={onSelectPublished}
+                    value={publishedValue}
+                    fullWidth
+                    size="long"
+                  />
+                </div>
+              )}
             </div>
 
             <div className="flex flex-col gap-3 sm:flex-row">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 export const Footer = () => {
   return (
-    <footer className="bg-black px-4 py-3 text-white">
-      <div className="mx-auto ml-8 max-w-7xl">
-        <div className="mb-2">
+    <footer className="bg-black px-4 py-1 text-white">
+      <div className="mx-auto ml-0 max-w-7xl md:ml-8">
+        <div>
           <a
-            className="inline-flex cursor-pointer items-center text-2xl font-bold transition-opacity hover:opacity-80"
+            className="inline-flex cursor-pointer items-center text-base font-bold transition-opacity hover:opacity-80"
             href="https://www.hopeful.pro/"
             target="_blank"
             rel="noopener noreferrer"
@@ -14,7 +14,7 @@ export const Footer = () => {
             Hopeful
           </a>
         </div>
-        <div className="mb-1 text-xs">
+        <div className="text-xs">
           TECNOPUC | Prédio 96A | Sala 215 | Av. Ipiranga, 6681 - Partenon,
           Porto Alegre - RS, 90619-900
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { LogOut, LogIn } from 'lucide-react';
+import { LogOut, LogIn, Plus } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -19,20 +19,20 @@ export default function Header() {
   if (!shouldRenderHeader) return null;
 
   return (
-    <header className="fixed top-0 left-0 z-100 flex w-full items-center justify-between bg-black px-6 py-2 text-gray-300">
+    <header className="fixed top-0 left-0 z-100 flex w-full items-center justify-between bg-black px-4 py-2 text-gray-300">
       <div className="flex items-center gap-2">
         <Link href="https://www.hopeful.pro/">
           <Image
             src="/logoHopeful.png"
             alt="Hopeful Icon"
-            width={40}
-            height={40}
+            width={32}
+            height={32}
             className="rounded"
           />
         </Link>
       </div>
 
-      <div className="mr-auto ml-14 hidden items-center gap-8 text-lg font-medium md:flex">
+      <div className="mr-auto ml-14 hidden items-center gap-6 text-base font-medium md:flex">
         {links.map(({ href, label }) => (
           <Link
             key={href}
@@ -44,31 +44,32 @@ export default function Header() {
         ))}
       </div>
 
-      <div className="flex items-center gap-6">
+      <div className="flex items-center gap-4">
         {(role === Role.ADMIN || role === Role.USER) && (
           <Link
             href={role === Role.ADMIN ? '/admin/create-scenario' : '/user'}
-            className="inline-flex h-8 w-52 items-center justify-center gap-2 rounded-lg bg-blue-600 px-3 text-sm font-medium text-white transition-colors hover:bg-blue-900 focus-visible:ring-0 focus-visible:outline-none active:bg-blue-800"
+            className="inline-flex h-9 items-center justify-center gap-2 rounded-lg bg-blue-600 px-3 text-sm font-medium text-white transition-colors hover:bg-blue-900 focus-visible:ring-0 focus-visible:outline-none active:bg-blue-800"
           >
-            Criar Cenário
+            <Plus className="h-5 w-5 md:hidden" />
+            <span className="hidden md:inline">Criar Cenário</span>
           </Link>
         )}
 
         {isAuthenticated ? (
           <button
             onClick={logout}
-            className="inline-flex h-10 w-9 items-center justify-center rounded-md hover:bg-gray-800"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md hover:bg-gray-800"
             title="Sair"
           >
-            <LogOut className="h-6 w-6" />
+            <LogOut className="h-5 w-5" />
           </button>
         ) : (
           <button
             onClick={() => router.push('/login')}
-            className="inline-flex h-10 w-9 items-center justify-center rounded-md hover:bg-gray-800"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md hover:bg-gray-800"
             title="Entrar"
           >
-            <LogIn className="h-6 w-6" />
+            <LogIn className="h-5 w-5" />
           </button>
         )}
       </div>


### PR DESCRIPTION
## Link da Tarefa

https://app.clickup.com/t/86b7d79ee

## Descrição

Melhora a responsividade da listagem de planos do admin e componentes globais

- Página /admin/plans agora totalmente responsiva: tabela em desktop/tablet e cards no mobile
- Adicionado componente AdminPlanCard para visualização mobile
- Atualizados filtros: FiltersBar no desktop e modal no mobile
- Melhorados Header, Footer e Button para telas pequenas

## Checklist

- [x] Não deixou string literais no código.
- [x] Utilizou as variáveis padronizadas do design system (cor, títulos/fontes).
- [x] Não deixou código comentado.

## Screenshots da tela/componente

<img width="402" height="776" alt="Captura de Tela 2025-11-08 às 16 01 04" src="https://github.com/user-attachments/assets/c884ddd9-25c7-4cb5-b8ae-3646696f83e4" />

<img width="415" height="778" alt="Captura de Tela 2025-11-08 às 16 01 14" src="https://github.com/user-attachments/assets/910957ab-4006-4843-ab2b-27ff06aec165" />

<img width="402" height="778" alt="Captura de Tela 2025-11-08 às 16 01 25" src="https://github.com/user-attachments/assets/99948b49-614e-46da-b558-6593aa220ea9" />
